### PR TITLE
Mocks and Stubs

### DIFF
--- a/test/museum_test.rb
+++ b/test/museum_test.rb
@@ -64,11 +64,13 @@ class MuseumTest <Minitest::Test
   end
 
   def test_it_can_tell_you_the_average_exhibit_cost
-    skip
     dmns = Museum.new("Denver Museum of Nature and Science")
-    gems_and_minerals = Exhibit.new("Gems and Minerals", 4)
-    dead_sea_scrolls = Exhibit.new("Dead Sea Scrolls", 11)
-    imax = Exhibit.new("IMAX", 15)
+    gems_and_minerals = mock("Gems and Minerals")
+    dead_sea_scrolls = mock("Dead Sea Scrolls")
+    imax = mock("IMAX")
+    gems_and_minerals.stubs(:cost).returns(4)
+    dead_sea_scrolls.stubs(:cost).returns(11)
+    imax.stubs(:cost).returns(15)
     dmns.add_exhibit(gems_and_minerals)
     dmns.add_exhibit(dead_sea_scrolls)
     dmns.add_exhibit(imax)

--- a/test/museum_test.rb
+++ b/test/museum_test.rb
@@ -49,11 +49,13 @@ class MuseumTest <Minitest::Test
   end
 
   def test_it_can_list_admitted_patrons_by_name
-    skip
     dmns = Museum.new("Denver Museum of Nature and Science")
 
-    bob = Patron.new("Bob", 20)
-    sally = Patron.new("Sally", 20)
+    bob = mock("Bob")
+    sally = mock("Sally")
+
+    bob.stubs(:name).returns("Bob")
+    sally.stubs(:name).returns("Sally")
 
     dmns.admit(bob)
     dmns.admit(sally)

--- a/test/museum_test.rb
+++ b/test/museum_test.rb
@@ -80,20 +80,25 @@ class MuseumTest <Minitest::Test
 
   def test_there_are_recommended_exhibits_for_a_given_patron
     ###CHALLENGE
-    skip
-    gems_and_minerals = Exhibit.new("Gems and Minerals", 0)
-    dead_sea_scrolls = Exhibit.new("Dead Sea Scrolls", 10)
-    imax = Exhibit.new("IMAX", 15)
+    gems_and_minerals = mock("Gems and Minerals")
+    dead_sea_scrolls = mock("Dead Sea Scrolls")
+    imax = mock("IMAX")
+    gems_and_minerals.stubs(:name).returns("Gems and Minerals")
+    dead_sea_scrolls.stubs(:name).returns("Dead Sea Scrolls")
+    imax.stubs(:name).returns("IMAX")
     dmns = Museum.new("Denver Museum of Nature and Science")
     dmns.add_exhibit(gems_and_minerals)
     dmns.add_exhibit(dead_sea_scrolls)
     dmns.add_exhibit(imax)
-    bob = Patron.new("Bob", 20)
-    bob.add_interest("Dead Sea Scrolls")
-    bob.add_interest("Gems and Minerals")
-    sally = Patron.new("Sally", 20)
-    sally.add_interest("IMAX")
-    #hint: look at the recommend_exhibits() method and figure out which method you need to be called on which object, and then stub from there.
+    bob = mock("Bob")
+    bob.stubs(:add_interest).with("Dead Sea Scrolls").returns(nil)
+    bob.stubs(:add_interest).with("Gems and Minerals").returns(nil)
+    bob.stubs(:interests).returns(["Dead Sea Scrolls", "Gems and Minerals"])
+    sally = mock("Sally")
+    sally.stubs(:add_interest).with("IMAX").returns(nil)
+    sally.stubs(:interests).returns(["IMAX"])
+
+
     assert_equal [gems_and_minerals,dead_sea_scrolls], dmns.recommend_exhibits(bob)
     assert_equal [imax], dmns.recommend_exhibits(sally)
   end

--- a/test/museum_test.rb
+++ b/test/museum_test.rb
@@ -31,18 +31,16 @@ class MuseumTest <Minitest::Test
 
 
   def test_patrons_starts_empty
-    skip
     dmns = Museum.new("Denver Museum of Nature and Science")
 
     assert_equal [], dmns.patrons
   end
 
   def test_it_can_admit_patrons
-    skip
     dmns = Museum.new("Denver Museum of Nature and Science")
 
-    bob = Patron.new("Bob", 20)
-    sally = Patron.new("Sally", 20)
+    bob = mock("Bob")
+    sally = mock("Sally")
 
     dmns.admit(bob)
     dmns.admit(sally)

--- a/test/museum_test.rb
+++ b/test/museum_test.rb
@@ -1,6 +1,7 @@
 require 'minitest/autorun'
 require 'minitest/pride'
 require './lib/museum'
+require 'mocha/minitest'
 
 class MuseumTest <Minitest::Test
 
@@ -17,10 +18,9 @@ class MuseumTest <Minitest::Test
   end
 
   def test_it_can_add_exhibits
-    skip
-    gems_and_minerals = Exhibit.new("Gems and Minerals", 0)
-    dead_sea_scrolls = Exhibit.new("Dead Sea Scrolls", 10)
-    imax = Exhibit.new("IMAX", 15)
+    gems_and_minerals = mock("Gems and Minerals")
+    dead_sea_scrolls = mock("Dead Sea Scrolls")
+    imax = mock("IMAX")
     dmns = Museum.new("Denver Museum of Nature and Science")
     dmns.add_exhibit(gems_and_minerals)
     dmns.add_exhibit(dead_sea_scrolls)


### PR DESCRIPTION
- Adds mocks and stubs to allow tests to pass without Patron and Exhibit classes or methods defined
- Notes:
  - require 'mocha/minitest'
  - For mocking: object_name = mock("object name")
  - For stubbing: object_name.stubs(:method_name).returns(return value)
  - For stubbing w/ argument: object_name.stubs(:method_name).with(args).returns(return value)